### PR TITLE
Fix the floating WP footer [WML-11]

### DIFF
--- a/src/WPML_OptionsManager.php
+++ b/src/WPML_OptionsManager.php
@@ -591,7 +591,6 @@ class WPML_OptionsManager {
                 ?>
             </form>
             <?php $this->displayMP3Banner() ?>
-        </div>
         <?php
     }
 


### PR DESCRIPTION
There was an extra closing `</div>` tag, causing `div#wpfooter` to no longer be a child of the containing `#wpwrap`, causing the relative positioning container to change.