### PR TITLE
Fix contextual_help deprecation notice

### DIFF
--- a/src/WPML_OptionsManager.php
+++ b/src/WPML_OptionsManager.php
@@ -342,7 +342,7 @@ class WPML_OptionsManager {
             $pluginNameSlug . '_about',
             array(&$this, 'LogSubMenuAbout') );
 
-        add_action( 'contextual_help', array( &$this, 'create_settings_panel' ), 10, 3 );
+        add_action( 'add_help_tab', array( &$this, 'create_settings_panel' ), 10, 3 );
     }
 
     public function LogSubMenuAbout() {


### PR DESCRIPTION
Fixes #113 

Updates deprecated hook of `contextual_help` with `add_help_tab` to stop notices. 